### PR TITLE
allow usage of pre allocated bytes.buffers for compression

### DIFF
--- a/lzop/lzop.go
+++ b/lzop/lzop.go
@@ -21,12 +21,10 @@ const (
 )
 
 var lzopMagic = []byte{0x89, 0x4c, 0x5a, 0x4f, 0x00, 0x0d, 0x0a, 0x1a, 0x0a}
+var endBytes = []byte{0x00, 0x00, 0x00, 0x00}
 
-//CompressData Will Compress your data expecting an LZO 1X1 compression.
-func CompressData(fileTime int64, fileName string, data []byte,
-	compressionFunction func([]byte) []byte) ([]byte, error) {
-
-	buff := bytes.NewBuffer(make([]byte, 0, bytes.MinRead))
+func writeData(buff *bytes.Buffer, fileTime int64, fileName string, data []byte,
+	compressionFunction func([]byte) []byte) error {
 
 	err := binary.Write(buff, binary.BigEndian, uint16(version))
 	err = binary.Write(buff, binary.BigEndian, uint16(libVersion))
@@ -40,6 +38,10 @@ func CompressData(fileTime int64, fileName string, data []byte,
 	err = binary.Write(buff, binary.BigEndian, uint8(len(fileName)))
 	_, err = buff.Write([]byte(fileName))
 	err = binary.Write(buff, binary.BigEndian, uint32(adler32.Checksum(buff.Bytes())))
+
+	if err != nil {
+		return err
+	}
 
 	blockSize := 256 * 1024
 
@@ -78,14 +80,60 @@ func CompressData(fileTime int64, fileName string, data []byte,
 		err = binary.Write(buff, binary.BigEndian, uint32(len(compressed)))
 		err = binary.Write(buff, binary.BigEndian, uint32(adler32.Checksum(unCompressed)))
 
+		if err != nil {
+			return err
+		}
+
 		buff.Write(compressed)
+	}
+
+	return err
+}
+
+//CompressData Will Compress your data expecting an LZO 1X1 compression.
+func CompressData(fileTime int64, fileName string, data []byte,
+	compressionFunction func([]byte) []byte) ([]byte, error) {
+
+	buff := bytes.NewBuffer(make([]byte, 0, bytes.MinRead))
+
+	err := writeData(buff, fileTime, fileName, data, compressionFunction)
+
+	if err != nil {
+		return nil, err
 	}
 
 	end := bytes.NewBuffer(make([]byte, 0, bytes.MinRead))
 
 	err = binary.Write(end, binary.BigEndian, lzopMagic)
 	end.Write(buff.Bytes())
-	end.Write([]byte("\x00\x00\x00\x00"))
+	end.Write(endBytes)
 
 	return end.Bytes(), err
+}
+
+//CompressDataWithBuffers Allows you to specify the buffer to use for compression and ending output
+//this allows re-use
+func CompressDataWithBuffers(compressBuffer, endBuffer *bytes.Buffer, fileTime int64, fileName string, data []byte,
+	compressionFunction func([]byte) []byte) ([]byte, error) {
+
+	compressBuffer.Reset()
+	endBuffer.Reset()
+
+	err := writeData(compressBuffer, fileTime, fileName, data, compressionFunction)
+
+	if err != nil {
+		return nil, err
+	}
+
+	err = binary.Write(endBuffer, binary.BigEndian, lzopMagic)
+	endBuffer.Write(compressBuffer.Bytes())
+	endBuffer.Write(endBytes)
+
+	return endBuffer.Bytes(), err
+}
+
+//GetAddedBufferLength Returns you the added byte size of characters
+//this is so you can pre-size the end buffer coming in and it wont resize
+func GetAddedBufferLength() int {
+	return len(lzopMagic) + len(endBytes)
 }


### PR DESCRIPTION
````
go test -test.bench .
goos: linux
goarch: amd64
pkg: github.com/MediaMath/go-lzop/lzop
BenchmarkAlloc-8      	      30	  52261686 ns/op
BenchmarkPreAlloc-8   	      50	  28636513 ns/op
PASS
ok  	github.com/MediaMath/go-lzop/lzop	48.863s
````